### PR TITLE
Update meeting pattern name

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -158,7 +158,7 @@
         </thead>
         <tbody>
           <tr><td colspan="4" style="background:#e0e7ef;font-weight:bold;">Before the meeting</td></tr>
-          <tr><td>Apply the efficient meeting pattern</td><td>✅</td><td>✅</td><td>✅</td></tr>
+          <tr><td>Apply the no time to waste pattern</td><td>✅</td><td>✅</td><td>✅</td></tr>
           <tr><td>Share the topic to be discussed, the goal of the discussion, and the success criteria</td><td>✅</td><td>✅</td><td>✅</td></tr>
           <tr><td>Share status elements in a known, shared, and archivable place (OneNote, Loop, Notion…)</td><td>✅</td><td>✅</td><td>✅</td></tr>
           <tr><td>Share documents to read/know to effectively conduct the meeting</td><td>✅</td><td>✅</td><td>✅</td></tr>
@@ -174,7 +174,7 @@
           <tr><td>Take 5 minutes at the end of the day to review the meetings for the next day and check for conflicts</td><td></td><td>✅</td><td>✅</td></tr>
           <tr><td>Take 5 minutes in the middle of the day to prepare for the meetings of the next day</td><td></td><td></td><td>✅</td></tr>
           <tr><td colspan="4" style="background:#e0e7ef;font-weight:bold;">During the meeting</td></tr>
-          <tr><td>Apply the efficient meeting pattern</td><td>✅</td><td>✅</td><td>✅</td></tr>
+          <tr><td>Apply the no time to waste pattern</td><td>✅</td><td>✅</td><td>✅</td></tr>
           <tr><td>Be on time for meetings</td><td>✅</td><td>✅</td><td>✅</td></tr>
           <tr><td>Postpone the meeting if the "mandatory" participants are not present</td><td>✅</td><td>✅</td><td>✅</td></tr>
           <tr><td>Ensure that time is managed (timekeeper)</td><td></td><td>✅</td><td>✅</td></tr>


### PR DESCRIPTION
## Summary
- replace occurrences of "efficient meeting pattern" with "no time to waste" in docs

## Testing
- `grep -n "no time to waste" -n docs/index.html`

------
https://chatgpt.com/codex/tasks/task_e_68779c1821f48323adc110f39f7c328a